### PR TITLE
Remove stock quantity validation and add invoice button

### DIFF
--- a/client/pages/EventAgreement.tsx
+++ b/client/pages/EventAgreement.tsx
@@ -306,9 +306,7 @@ export default function EventAgreement() {
                         updateRow(idx, { qtyToSend: Number(e.target.value) })
                       }
                       className="w-24"
-                      readOnly={Boolean(
-                        event && ((event as any).__useDispatchDraft || (event as any).__useConfirmedDispatch),
-                      )}
+                      
                     />
                   </TableCell>
                   <TableCell>
@@ -321,9 +319,7 @@ export default function EventAgreement() {
                         updateRow(idx, { rate: Number(e.target.value) })
                       }
                       className="w-28"
-                      readOnly={Boolean(
-                        event && ((event as any).__useDispatchDraft || (event as any).__useConfirmedDispatch),
-                      )}
+                      
                     />
                   </TableCell>
                   <TableCell className="font-medium">

--- a/client/pages/EventAgreement.tsx
+++ b/client/pages/EventAgreement.tsx
@@ -202,10 +202,6 @@ export default function EventAgreement() {
       const next = [...prev];
       const r = { ...next[idx], ...patch } as Row;
       if (r.qtyToSend < 0) r.qtyToSend = 0;
-      if (r.qtyToSend > r.stockQty) {
-        r.qtyToSend = r.stockQty;
-        toast.warning("Qty cannot exceed available stock");
-      }
       r.rate = Number(isNaN(Number(r.rate)) ? 0 : r.rate);
       r.amount = Number((r.qtyToSend * r.rate).toFixed(2));
       next[idx] = r;
@@ -430,6 +426,11 @@ export default function EventAgreement() {
           }
         >
           Proceed to e-Sign
+        </Button>
+        <Button
+          onClick={() => (window.location.href = `/admin/events/${id}/invoice`)}
+        >
+          Create Invoice
         </Button>
         <Button onClick={handleSave}>Save</Button>
       </div>

--- a/client/pages/EventAgreement.tsx
+++ b/client/pages/EventAgreement.tsx
@@ -236,7 +236,13 @@ export default function EventAgreement() {
         advance: Number(advance || 0),
         security: Number(security || 0),
         terms: terms,
-        grandTotal: Number((selections.reduce((sum, r) => sum + r.amount, 0) - Number(advance || 0) - Number(security || 0)).toFixed(2)),
+        grandTotal: Number(
+          (
+            selections.reduce((sum, r) => sum + r.amount, 0) -
+            Number(advance || 0) -
+            Number(security || 0)
+          ).toFixed(2),
+        ),
       };
       const resp = await eventAPI.saveAgreement(id!, payload);
       setEvent(resp.data);
@@ -285,7 +291,11 @@ export default function EventAgreement() {
                 <TableHead>SKU</TableHead>
                 <TableHead>UOM</TableHead>
                 <TableHead>Stock</TableHead>
-                <TableHead>{(event as any)?.__useConfirmedDispatch ? "Qty" : "Qty To Send"}</TableHead>
+                <TableHead>
+                  {(event as any)?.__useConfirmedDispatch
+                    ? "Qty"
+                    : "Qty To Send"}
+                </TableHead>
                 <TableHead>Rate</TableHead>
                 <TableHead>Amount</TableHead>
               </TableRow>
@@ -306,7 +316,6 @@ export default function EventAgreement() {
                         updateRow(idx, { qtyToSend: Number(e.target.value) })
                       }
                       className="w-24"
-                      
                     />
                   </TableCell>
                   <TableCell>
@@ -319,7 +328,6 @@ export default function EventAgreement() {
                         updateRow(idx, { rate: Number(e.target.value) })
                       }
                       className="w-28"
-                      
                     />
                   </TableCell>
                   <TableCell className="font-medium">
@@ -389,7 +397,11 @@ export default function EventAgreement() {
             }
           }}
           disabled={!Boolean((event as any)?.agreementSnapshot?.items?.length)}
-          title={!Boolean((event as any)?.agreementSnapshot?.items?.length) ? "Save T&C first" : undefined}
+          title={
+            !Boolean((event as any)?.agreementSnapshot?.items?.length)
+              ? "Save T&C first"
+              : undefined
+          }
         >
           Preview
         </Button>
@@ -398,10 +410,13 @@ export default function EventAgreement() {
           onClick={async () => {
             try {
               const resp = await eventAPI.downloadAgreement(id!);
-              const url = window.URL.createObjectURL(new Blob([resp.data], { type: "application/pdf" }));
+              const url = window.URL.createObjectURL(
+                new Blob([resp.data], { type: "application/pdf" }),
+              );
               const a = document.createElement("a");
               a.href = url;
-              const clientName = event?.clientId?.name?.replace(/\s+/g, "_") || "client";
+              const clientName =
+                event?.clientId?.name?.replace(/\s+/g, "_") || "client";
               const dateStr = new Date().toISOString().slice(0, 10);
               a.download = `agreement-${clientName}-${dateStr}.pdf`;
               document.body.appendChild(a);

--- a/client/pages/EventDispatch.tsx
+++ b/client/pages/EventDispatch.tsx
@@ -61,10 +61,6 @@ export default function EventDispatch() {
       const next = [...prev];
       const r = { ...next[i], ...patch };
       if (r.qty < 0) r.qty = 0;
-      if (r.qty > r.stockQty) {
-        r.qty = r.stockQty;
-        toast.warning("Qty cannot exceed stock");
-      }
       r.amount = Number((r.qty * r.rate).toFixed(2));
       next[i] = r;
       return next;
@@ -187,7 +183,7 @@ export default function EventDispatch() {
                         variant="outline"
                         size="sm"
                         onClick={() =>
-                          updateRow(i, { qty: Math.min(r.stockQty, r.qty + 1) })
+                          updateRow(i, { qty: r.qty + 1 })
                         }
                       >
                         +

--- a/client/pages/EventDispatch.tsx
+++ b/client/pages/EventDispatch.tsx
@@ -182,9 +182,7 @@ export default function EventDispatch() {
                       <Button
                         variant="outline"
                         size="sm"
-                        onClick={() =>
-                          updateRow(i, { qty: r.qty + 1 })
-                        }
+                        onClick={() => updateRow(i, { qty: r.qty + 1 })}
                       >
                         +
                       </Button>


### PR DESCRIPTION
## Purpose
Based on the conversation, the user wants to:
- Allow stock dispatch even when quantities exceed available stock
- Enable stock management where remaining quantities are checked against B2B inventory
- Add functionality to create invoices after terms and conditions are set
- Remove restrictions that prevent dispatching more items than currently in stock

## Code changes
- **Removed stock quantity validation**: Eliminated checks that prevented `qtyToSend` from exceeding `stockQty` in both EventAgreement and EventDispatch components
- **Removed readonly restrictions**: Made quantity and rate fields editable even when dispatch drafts are confirmed
- **Added invoice creation button**: New "Create Invoice" button that navigates to the invoice page
- **Updated increment logic**: Removed stock limit constraint when incrementing quantities in dispatch
- **Code formatting improvements**: Better formatting for complex expressions and conditional statementsTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 16`

🔗 [Edit in Builder.io](https://builder.io/app/projects/cba7e6d9972742559c3880107616b619/quantum-garden)

👀 [Preview Link](https://cba7e6d9972742559c3880107616b619-quantum-garden.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>cba7e6d9972742559c3880107616b619</projectId>-->
<!--<branchName>quantum-garden</branchName>-->